### PR TITLE
이름으로 검색 기능 완료

### DIFF
--- a/src/main/java/com/powerGoorm/member/MemberController.java
+++ b/src/main/java/com/powerGoorm/member/MemberController.java
@@ -3,6 +3,7 @@ package com.powerGoorm.member;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -16,5 +17,10 @@ public class MemberController {
 	@GetMapping("/member")
 	public List<MemberDto> getMember() {
 		return memberService.getMember();
+	}
+
+	@GetMapping("/member/search")
+	public List<MemberDto> searchMember(@RequestParam String name) {
+		return memberService.searchByName(name);
 	}
 }

--- a/src/main/java/com/powerGoorm/member/MemberRepository.java
+++ b/src/main/java/com/powerGoorm/member/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.powerGoorm.member;
 
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
+	List<Member> findAllByName(String name);
 }

--- a/src/main/java/com/powerGoorm/member/MemberService.java
+++ b/src/main/java/com/powerGoorm/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.powerGoorm.member;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -20,5 +21,17 @@ public class MemberService {
 			.stream()
 			.map(Member::toDto)
 			.collect(Collectors.toList());
+	}
+
+	public List<MemberDto> searchByName(String name) {
+		List<MemberDto> result = memberRepository.findAllByName(name)
+			.stream()
+			.map(Member::toDto)
+			.collect(Collectors.toList());
+
+		if (result.isEmpty()) {
+			throw new NoSuchElementException("No member found with name:" + name);
+		}
+		return result;
 	}
 }

--- a/src/test/java/com/powerGoorm/api/Member.http
+++ b/src/test/java/com/powerGoorm/api/Member.http
@@ -1,3 +1,7 @@
 ### 멤버페이지
 GET localhost:8080/member
 Content-Type: application/json
+
+###멤버 이름 검색
+GET localhost:8080/member/search?name=권지환
+Content-Type: application/json


### PR DESCRIPTION
예외처리를 통해 존재하지 않은 이름으로 검색했을 때 500 에러가 뜨도록 했습니다.